### PR TITLE
Multiple bug fixes

### DIFF
--- a/socialNetwork/helm-chart/socialnetwork/charts/compose-post-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/compose-post-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "75m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-redis/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-redis/values.yaml
@@ -14,7 +14,7 @@ container:
   - containerPort: 6379
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: redis.conf

--- a/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/home-timeline-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/jaeger/values.yaml
@@ -24,7 +24,7 @@ container:
   - name: COLLECTOR_ZIPKIN_HTTP_PORT
     value: 9411
   image: jaegertracing/all-in-one
-  imageVersion: latest
+  imageVersion: 1.62.0
   name: jaeger
   ports: 
   - containerPort: 5775

--- a/socialNetwork/helm-chart/socialnetwork/charts/media-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/media-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/post-storage-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/post-storage-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/social-graph-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/social-graph-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/text-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/text-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/unique-id-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/unique-id-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/url-shorten-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/url-shorten-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-mention-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-mention-service/values.yaml
@@ -12,7 +12,7 @@ container:
     - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "50m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/helm-chart/socialnetwork/charts/user-timeline-service/values.yaml
+++ b/socialNetwork/helm-chart/socialnetwork/charts/user-timeline-service/values.yaml
@@ -12,7 +12,7 @@ container:
   - containerPort: 9090
   resources:
     limits:
-      cpu: "25m"
+      cpu: "1000m"
 
 configMaps:
   - name: jaeger-config.yml

--- a/socialNetwork/k8startup.sh
+++ b/socialNetwork/k8startup.sh
@@ -51,14 +51,6 @@ else
 	echo "Ports for kube tunnel already forwarded"
 fi
 
-screen -ls | grep "\.prom-pf[[:space:]]" > /dev/null
-if [ $? -ne 0 ]; then
-	echo "Ports for prometheus forwarded"
-	screen -dmS prom-pf bash -c "./pod_running_check.sh 'monitoring' 'prometheus-server'; kubectl config set-context --current --namespace=monitoring; kubectl get pods | grep prometheus-server | awk '{print \$1}' | xargs -I {} kubectl port-forward {} 9090"
-else
-	echo "Ports for prometheus already forwarded"
-fi
-
 screen -ls | grep "\.chaos-pf[[:space:]]" > /dev/null
 if [ $? -ne 0 ]; then
 	echo "Ports for chaos forwarded"
@@ -73,6 +65,14 @@ if [ $? -ne 0 ]; then
 	screen -dmS jaeger-pf bash -c "./pod_running_check.sh 'socialnetwork' 'jaeger'; kubectl config set-context --current --namespace=socialnetwork; kubectl get pods | grep jaeger | awk '{print \$1}' | xargs -I {} kubectl port-forward {} 16686:16686"
 else
 	echo "Ports for jaeger already forwarded"
+fi
+
+screen -ls | grep "\.prom-pf[[:space:]]" > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Ports for prometheus forwarded"
+	screen -dmS prom-pf bash -c "./pod_running_check.sh 'monitoring' 'prometheus-server'; kubectl config set-context --current --namespace=monitoring; kubectl get pods | grep prometheus-server | awk '{print \$1}' | xargs -I {} kubectl port-forward {} 9090"
+else
+	echo "Ports for prometheus already forwarded"
 fi
 
 # Deploy and patch Metrics Server for autoscaling


### PR DESCRIPTION
- switch jaeger/all-in-one Docker image from `latest` to `1.62.0` as `latest` now seems to completely break tracing for the social network deployment.
- increase CPU limits in `helm-chart` as they were abnormally low and degrading performance.
- fix an edge case where the port for Prometheus was not forwarded correctly.